### PR TITLE
(feat) Close #20: Capture local video

### DIFF
--- a/src/pages/video/Video.vue
+++ b/src/pages/video/Video.vue
@@ -22,35 +22,53 @@ import TranslationsPanel from './components/TranslationsPanel.vue'
 import TextBox from './components/TextBox.vue'
 
 export default {
+  // State variables.
+  // ================
+  data: function () {
+    return {
+      localVideo: '',
+      localVideoStream: '',
+    }
+  },
+  // Controller methods.
+  // ===================
   methods: {
     captureLocalVideo: function () {
       console.log('Beginning video capture...')
-      var localVideo;
-      var localVideoStream;
       var constraints = {audio: true, video: true};
 
       navigator.mediaDevices.getUserMedia(constraints)
       .then((stream) => {
         // console.dir(stream.getAudioTracks());
-        localVideo = document.getElementById('local-video');
-        localVideoStream = URL.createObjectURL(stream);
-        localVideo.src = localVideoStream;
+        this.localVideoStream = URL.createObjectURL(stream);
+        this.localVideo.src = this.localVideoStream;
       })
       .catch((err) => {
         console.error('Failed to acquire local video/audio stream.\n', err);
       })
     },
+
+    endVideoCapture: function () {
+      console.log('Ending video capture...')
+    },
   },
-  mounted: function () {
-    this.captureLocalVideo()
-  },
+  // Custom components.
+  // ==================
   components: {
     ChatsPanel,
     TranslationsPanel,
     TextBox
-  }
+  },
+  // Lifecycle hooks
+  // ===============
+  mounted: function () {
+    this.localVideo = document.getElementById('local-video')
+    this.captureLocalVideo()
+  },
+  beforeDestroy: function () {
+    this.endVideoCapture()
+  },
 }
-
 </script>
 
 

--- a/src/pages/video/Video.vue
+++ b/src/pages/video/Video.vue
@@ -26,30 +26,37 @@ export default {
   // ================
   data: function () {
     return {
-      localVideo: '',
-      localVideoStream: '',
+      localVideo: '',  // Set by startVideoCapture().
+      localVideoStream: '',  // Set by startVideoCapture().
     }
   },
   // Controller methods.
   // ===================
   methods: {
-    captureLocalVideo: function () {
-      console.log('Beginning video capture...')
-      var constraints = {audio: true, video: true};
+    startVideoCapture: function () {
+      console.log('Starting video capture...')
+      var constraints = {audio: true, video: true}
+
+      this.localVideo = document.getElementById('local-video')
 
       navigator.mediaDevices.getUserMedia(constraints)
       .then((stream) => {
         // console.dir(stream.getAudioTracks());
-        this.localVideoStream = URL.createObjectURL(stream);
-        this.localVideo.src = this.localVideoStream;
+        this.localVideoStream = stream
+        this.localVideo.src = URL.createObjectURL(stream)
       })
       .catch((err) => {
-        console.error('Failed to acquire local video/audio stream.\n', err);
+        console.error('Failed to acquire local video/audio stream.\n', err)
       })
     },
 
-    endVideoCapture: function () {
+    stopVideoCapture: function () {
       console.log('Ending video capture...')
+      // Need to call stop() on each track in stream.
+      var tracks = this.localVideoStream.getTracks()
+      tracks.forEach(function (track) {
+        track.stop()
+      })
     },
   },
   // Custom components.
@@ -62,11 +69,11 @@ export default {
   // Lifecycle hooks
   // ===============
   mounted: function () {
-    this.localVideo = document.getElementById('local-video')
-    this.captureLocalVideo()
+    this.startVideoCapture()
   },
+
   beforeDestroy: function () {
-    this.endVideoCapture()
+    this.stopVideoCapture()
   },
 }
 </script>

--- a/src/pages/video/Video.vue
+++ b/src/pages/video/Video.vue
@@ -2,12 +2,12 @@
 <div id="video-page">
   <chats-panel></chats-panel>
   <div id="videos">
-    <div id="remote-video">
-      <video autoplay="true"></video>
+    <div>
+      <video id="remote-video" autoplay="true"></video>
       <text-box :message="{text:'User_0'}"></text-box>
     </div>
-    <div id="local-video">
-      <video autoplay="true"></video>
+    <div>
+      <video id="local-video" autoplay="true"></video>
       <text-box :message="{text:'User_1'}"></text-box>
     </div>
   </div>
@@ -29,7 +29,8 @@ export default {
   }
 }
 
-/* Video capture/render. Integrate on DOM mount.
+// Video capture/render. Integrate on DOM mount.
+// =============================================
 // var wsc = new WebSocket('ws://localhost:8080/websocket/');
 // var peerConnCfg = {
 //   'iceServers': [
@@ -46,7 +47,7 @@ function pageReady() {
   navigator.mediaDevices.getUserMedia(constraints).then(
   (stream) => {
     // console.dir(stream.getAudioTracks());
-    localVideo = document.getElementById('localVideo');
+    localVideo = document.getElementById('local-video');
     localVideoStream = URL.createObjectURL(stream);
     localVideo.src = localVideoStream;
   }).catch(
@@ -57,7 +58,7 @@ function pageReady() {
 };
 
 window.addEventListener("load", pageReady);
-*/
+
 </script>
 
 

--- a/src/pages/video/Video.vue
+++ b/src/pages/video/Video.vue
@@ -22,42 +22,34 @@ import TranslationsPanel from './components/TranslationsPanel.vue'
 import TextBox from './components/TextBox.vue'
 
 export default {
+  methods: {
+    captureLocalVideo: function () {
+      console.log('Beginning video capture...')
+      var localVideo;
+      var localVideoStream;
+      var constraints = {audio: true, video: true};
+
+      navigator.mediaDevices.getUserMedia(constraints)
+      .then((stream) => {
+        // console.dir(stream.getAudioTracks());
+        localVideo = document.getElementById('local-video');
+        localVideoStream = URL.createObjectURL(stream);
+        localVideo.src = localVideoStream;
+      })
+      .catch((err) => {
+        console.error('Failed to acquire local video/audio stream.\n', err);
+      })
+    },
+  },
+  mounted: function () {
+    this.captureLocalVideo()
+  },
   components: {
     ChatsPanel,
     TranslationsPanel,
     TextBox
   }
 }
-
-// Video capture/render. Integrate on DOM mount.
-// =============================================
-// var wsc = new WebSocket('ws://localhost:8080/websocket/');
-// var peerConnCfg = {
-//   'iceServers': [
-//     {'url': 'stun:stun.services.mozilla.com'},
-//     {'url': 'stun:stun.l.google.com:19302'}
-//   ]
-// };
-var localVideo;
-var localVideoStream;
-
-let constraints = {audio: true, video: true};
-
-function pageReady() {
-  navigator.mediaDevices.getUserMedia(constraints).then(
-  (stream) => {
-    // console.dir(stream.getAudioTracks());
-    localVideo = document.getElementById('local-video');
-    localVideoStream = URL.createObjectURL(stream);
-    localVideo.src = localVideoStream;
-  }).catch(
-  (err) => {
-    console.error('Failed to acquire local video/audio stream.\n', err);
-  });
-
-};
-
-window.addEventListener("load", pageReady);
 
 </script>
 


### PR DESCRIPTION
This patch
- captures the webcam when the user navigates to the Video page, and
- releases the webcam when the user navigates away from the Video page.

*** Webcam capture was originally implemented by @mschlesk; I merely wrapped it within a handler that waits for the video page to mount before executing.